### PR TITLE
Indent #define with 4 spaces instead of tab on post2017 header type (fix #8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,3 +81,7 @@ All notable changes to the "EPITECH C/C++ Headers" extension will be documented 
 
 - Added support for Haskell files
 - Fixed issue where normal files could be flagged as C/C++ files for header generation
+
+## 1.9.6
+
+- Fixed indentation issue with auto-insertion of header define guards for C/C++ empty header files

--- a/README.md
+++ b/README.md
@@ -128,3 +128,7 @@ Added support for Rust files and C++ template files
 
 Added support for Haskell files  
 Fixed issue where normal files could be flagged as C/C++ files for header generation  
+
+### 1.9.6
+
+Fixed indentation issue with auto-insertion of header define guards for C/C++ empty header files

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "epitech-c-cpp-headers",
     "displayName": "EPITECH C/C++ Headers",
     "description": "An EPITECH header handler for C/C++ projects",
-    "version": "1.9.5",
+    "version": "1.9.6",
     "publisher": "nicolaspolomack",
     "repository": {
         "type": "git",

--- a/src/generators.ts
+++ b/src/generators.ts
@@ -47,7 +47,10 @@ export function appendClass(editContent: string, className: string, fileInfo: Fi
 }
 
 export function appendIfndef(editContent: string, id: string, fileInfo: FileInfo, config: Config) {
-    return editContent.concat("#ifndef ", id, fileInfo.eol, Syntax[config.headerType].preProcessorStyle, "define ", id, fileInfo.eol, fileInfo.eol)
+    if (config.headerType == "post2017")
+        return editContent.concat("#ifndef ", id, fileInfo.eol, "    #define ", id, fileInfo.eol, fileInfo.eol);
+    else
+        return editContent.concat("#ifndef ", id, fileInfo.eol, Syntax[config.headerType].preProcessorStyle, "define ", id, fileInfo.eol, fileInfo.eol);
 }
 
 export function appendConstructorDestructor(editContent: string, className: string, fileInfo: FileInfo) {


### PR DESCRIPTION
I don't know how to write "clean" code in TypeScript, but this works.

I just added a condition (if the header type is `post2017`) and hardcoded the 4 spaces in the code (in the `appendIfndef` function)

This fixes #8 