### PR TITLE
Ability to rename header guards

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,7 +46,7 @@ export const Syntax = {
     },
     post2017: {
         offsetHeaderFile: 10,
-        preProcessorStyle: "    #"
+        preProcessorStyle: "#"
     },
     commentStart: { c: "/*", cpp: "/*", Makefile: "##", Python: "##", Shell: "##", LaTeX: "%%", Java: "/*", "C#": "/*", ObjectiveC: "/*", Rust: "//", Haskell: "--", Go: "//" },
     commentMid: { c: "**", cpp: "**", Makefile: "##", Python: "##", Shell: "##", LaTeX: "%%", Java: "**", "C#": "**", ObjectiveC: "**", Rust: "//", Haskell: "--", Go: "//" },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,7 +65,11 @@ export function activate(context: vscode.ExtensionContext) {
             const isEmptySourceFile = (fileInfo.document.getText() == '' && fileInfo.ext.match(/^(?:c|cpp|C|cc)$/));
 
             if (isEmptyHeaderFile) {
-                const name = path.basename(fileInfo.fileName).replace('.', '_').replace("-", "_").concat("_");
+                let name = await vscode.window.showInputBox({ prompt: "Type header definer: ", placeHolder: "Leave empty to use filename as header..."})
+                if (name === undefined) {
+                    name = path.basename(fileInfo.fileName);
+                }
+                name = name.replace(" ", "_").replace('.', '_').replace("-", "_").concat("_")
                 const id = name.toLocaleUpperCase();
                 const className = path.basename(fileInfo.fileName).substr(0, name.length - fileInfo.ext.length - 2);
                 if (config.usePragmaOnce)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,13 +66,17 @@ export function activate(context: vscode.ExtensionContext) {
 
             if (isEmptyHeaderFile) {
                 let name = await vscode.window.showInputBox({ prompt: "Type header definer: ", placeHolder: "Leave empty to use filename as header..."})
+                let index_char = 0;
+                while ((index_char = name.search(/([^A-Za-z0-9_])/)) != -1) {
+                    vscode.window.showErrorMessage("\'" + name[index_char] + "\' isn't accepted as character for the header guard. The header guard can just contain alphanumerical characters and '_'. Retype a valid name or leave empty to use the filename.")
+                    name = await vscode.window.showInputBox({ prompt: "Type header guard: ", placeHolder: "Reenter a valid guard or leave empty to use filename as header..."})
+                }
                 if (name === undefined) {
                     name = "";
                 } else if (name === '') {
-                    name = path.basename(fileInfo.fileName)
+                    name = path.basename(fileInfo.fileName).replace(/[^A-Za-z0-9]/g, "_").concat("_").toLocaleUpperCase();
                 }
-                name = name.replace(/ /g, "_").replace('.', '_').replace(/-/g, "_").concat("_")
-                const id = name.toLocaleUpperCase();
+                const id = name
                 const className = path.basename(fileInfo.fileName).substr(0, name.length - fileInfo.ext.length - 2);
                 if (config.usePragmaOnce)
                     editContent = editContent.concat("#pragma once", fileInfo.eol, fileInfo.eol);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -92,7 +92,7 @@ export function activate(context: vscode.ExtensionContext) {
             }
 
             if (isEmptySourceFile) {
-                const name = path.basename(fileInfo.fileName).replace('.', '_').replace("-", "_").concat("_");
+                const name = path.basename(fileInfo.fileName).replace(/[^A-Za-z0-9]/g, "_").concat("_");
                 const id = name.toLocaleUpperCase();
                 const className = path.basename(fileInfo.fileName).substr(0, name.length - fileInfo.ext.length - 2);
                 if (config.autoGenerateClasses && fileInfo.langId == "cpp" && isUpper(className[0]))

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,9 +67,11 @@ export function activate(context: vscode.ExtensionContext) {
             if (isEmptyHeaderFile) {
                 let name = await vscode.window.showInputBox({ prompt: "Type header definer: ", placeHolder: "Leave empty to use filename as header..."})
                 if (name === undefined) {
-                    name = path.basename(fileInfo.fileName);
+                    name = "";
+                } else if (name === '') {
+                    name = path.basename(fileInfo.fileName)
                 }
-                name = name.replace(" ", "_").replace('.', '_').replace("-", "_").concat("_")
+                name = name.replace(/ /g, "_").replace('.', '_').replace(/-/g, "_").concat("_")
                 const id = name.toLocaleUpperCase();
                 const className = path.basename(fileInfo.fileName).substr(0, name.length - fileInfo.ext.length - 2);
                 if (config.usePragmaOnce)


### PR DESCRIPTION
Add a new feature that we can add a more descriptive define for the files with `.h` extension.

> For example before it was:
#ifndef FILE_H_
#define FILE_H_

But with the new feature i add:
When we want to have a more descriptive define, it will ask us a 3rd entry, for the name of the define, if we left it blank it would take the filename as default.
Also, all the spaces, dashes `-` and dots will be replaced with `_`.

I also change the preprocessorstyle for the `post2017` because it makes an error of codding style because of the indentation.