### PR TITLE
Add `.mk` extension support for Makefiles

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,6 +20,7 @@ export const EXTENSION_TO_LANGUAGE = {
     "h++": "C++",
     go: "Go",
     Makefile: "Makefile",
+    mk: "Makefile",
     py: "Python",
     sh: "Shell",
     tex: "LaTeX",


### PR DESCRIPTION
This PR adds support for the `.mk` extension which is commonly used when you extracted part of a Makefile to a seperate file.

See more details in #88
