### PR TITLE
Custom Header Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ This extension uses the following configuration entries:
 - `epitech-c-cpp-headers.prompt`: Specify if the extension should prompt for unknown configuration fields (default: true)
 - `epitech-c-cpp-headers.usePragmaOnce`: Specifies if '#pragma once' should be used as header guard instead of '#ifndef ...' (default: false)
 - `epitech-c-cpp-headers.autoGenerateClasses`: Specifies if automatic C++ class generation is enabled (default: true)
+- `epitech-c-cpp-headers.customHeader`: Specifies a custom header to use instead of the regular Epitech header (default: null)
 
 Known Issues
 ------------

--- a/README.md
+++ b/README.md
@@ -19,8 +19,21 @@ You can create a header for a new file by:
 
 Each time you save a C or C++ file with a header, it will update it automatically.
 
-You can configure the headers in a very simple manner by executing the `epitech-c-cpp-headers.setConfig` command.  
+You can configure the headers in a very simple manner by executing the `epitech-c-cpp-headers.setConfig` command.
 By default, it will execute it on launch when a configuration field is left unknown.
+
+It is also possible to replace the regular Epitech header with a custom one by setting the `epitech-c-cpp-headers.customHeader` configuration field.
+
+```json
+{
+    "epitech-c-cpp-headers.customHeader": [
+        "HEADER LINE 1",
+        "HEADER LINE 2",
+        "HEADER LINE 3",
+        "..."
+    ]
+}
+```
 
 Requirements
 ------------
@@ -52,7 +65,7 @@ Initial release
 
 ### 1.1.0
 
-Added support for Makefiles  
+Added support for Makefiles
 Added better internal multi-language handling
 
 ### 1.2.0
@@ -61,9 +74,9 @@ Added prompt to improve UX while configuring
 
 ### 1.3.0
 
-Added the `epitech-c-cpp-headers.setConfig` command to reconfigure headers  
-Fixed regex escape issues  
-Fixed possible line mismatch on date updates  
+Added the `epitech-c-cpp-headers.setConfig` command to reconfigure headers
+Fixed regex escape issues
+Fixed possible line mismatch on date updates
 Fixed date update on Makefiles
 
 ### 1.3.1
@@ -80,45 +93,45 @@ Fixed issues in README.md
 
 ### 1.5.0
 
-Added support for Python, Shell scripts, C#, Objective-C, Java, LaTeX  
-Added better support for C++  
-Added End-of-line encoding independance, for inter-operability between different OSs  
+Added support for Python, Shell scripts, C#, Objective-C, Java, LaTeX
+Added better support for C++
+Added End-of-line encoding independance, for inter-operability between different OSs
 
 ### 1.6.0
 
-Added auto-insertion of header define guards for C/C++ empty header files  
-Added cursor auto-positionning, to set it ready to type  
+Added auto-insertion of header define guards for C/C++ empty header files
+Added cursor auto-positionning, to set it ready to type
 
 ### 1.7.0
 
-Added internal multi-format support  
-Implemented the new 2017 header format (Promo 2022)  
+Added internal multi-format support
+Implemented the new 2017 header format (Promo 2022)
 
 ### 1.7.3
 
-Changed pre-processors indent style for the 2017 header format  
+Changed pre-processors indent style for the 2017 header format
 
 ### 1.7.4
 
-Fixed C++ headers  
-Fixed issue with config being saved as local instead of global  
+Fixed C++ headers
+Fixed issue with config being saved as local instead of global
 
 ### 1.8.0
 
-Added support for '#pragma once' header guards (Thanks to @lodi-g for the pull request)  
-Added C++ automatic class generator in source and header files  
+Added support for '#pragma once' header guards (Thanks to @lodi-g for the pull request)
+Added C++ automatic class generator in source and header files
 
 ### 1.8.1
 
-Fixed scolar year in post2017 headers  
+Fixed scolar year in post2017 headers
 
 ### 1.8.2
 
-Fixed the day in pre2017 headers (Thanks to @SaShimy for the pull request)  
+Fixed the day in pre2017 headers (Thanks to @SaShimy for the pull request)
 
 ### 1.8.3
 
-Reverted the 1.8.1 patch as it was not correct to begin with  
+Reverted the 1.8.1 patch as it was not correct to begin with
 
 ### 1.9.0
 
@@ -126,17 +139,17 @@ Added header auto-filling (with workspace name and filename, thanks to @lodi-g f
 
 ### 1.9.1
 
-Fixed issues with auto-filled headers (Thanks to @MrYannKee for the bug report and pull request)  
-Fixed empty auto-filled headers for files without extensions (like Makefile)  
+Fixed issues with auto-filled headers (Thanks to @MrYannKee for the bug report and pull request)
+Fixed empty auto-filled headers for files without extensions (like Makefile)
 
 ### 1.9.2
 
-Added support for Rust files and C++ template files  
+Added support for Rust files and C++ template files
 
 ### 1.9.5
 
-Added support for Haskell files  
-Fixed issue where normal files could be flagged as C/C++ files for header generation  
+Added support for Haskell files
+Fixed issue where normal files could be flagged as C/C++ files for header generation
 
 ### 1.12.0
 
@@ -148,16 +161,16 @@ Added ability to rename **`#ifndef`** header guards (Thanks to @ColColty for the
 
 ### 1.14.0
 
-Added setting to toggle indentation of visibility specifiers in generated C++ class declarations.  
-Indentation in generated code now respects user's preferences instead of always using tabs.  
+Added setting to toggle indentation of visibility specifiers in generated C++ class declarations.
+Indentation in generated code now respects user's preferences instead of always using tabs.
 (Thanks to @Gr1moire for the pull request introducing these two features)
 
 ### 1.15.0
 
-Added support for Assembly files  
-Added support for HTML files, CSS files and JavaScript/TypeScript files (Thanks to @IchiiDev for the pull request)  
-Improved comment style for Haskell files (Thanks to @enzo-cesaretti for the pull request)  
+Added support for Assembly files
+Added support for HTML files, CSS files and JavaScript/TypeScript files (Thanks to @IchiiDev for the pull request)
+Improved comment style for Haskell files (Thanks to @enzo-cesaretti for the pull request)
 
 ### 1.16.0
 
-Added support for Makefile `.mk` files (Thanks to @C0Florent for the pull request)  
+Added support for Makefile `.mk` files (Thanks to @C0Florent for the pull request)

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
                 "epitech-c-cpp-headers.customHeader": {
                     "type": "array",
                     "default": [],
-                    "description": "Specifies custom headers to add to the generated headers."
+                    "description": "Specifies a custom header to use instead of the regular Epitech header."
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -97,6 +97,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Specifies if access specifiers indentation is enabled."
+                },
+                "epitech-c-cpp-headers.customHeader": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Specifies custom headers to add to the generated headers."
                 }
             }
         }

--- a/src/commands/add_header.ts
+++ b/src/commands/add_header.ts
@@ -107,7 +107,7 @@ export async function runAddHeader() {
 
     const extension = path.basename(fileInfo.fileName).split(".").reverse()[0];
     if (!isSupportedExtension(extension)) {
-        vscode.window.showErrorMessage("The currently opened file (" + extension + ") isn't a supported file.");
+        vscode.window.showErrorMessage(`The currently opened file (${extension}) isn't a supported file.`);
         return;
     }
 
@@ -126,7 +126,7 @@ export async function runAddHeader() {
         fileInfo.description = description;
     }
 
-    let editContent = GENERATORS[config.headerType](fileInfo, config, date);
+    let editContent = GENERATORS[(config.customHeader.length > 0) ? "custom" : config.headerType](fileInfo, config, date);
     let offsetY = SYNTAX[config.headerType].offsetHeaderFile;
     let offsetX = 0;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -83,6 +83,7 @@ export function loadConfig(): Config {
         usePragmaOnce: z.boolean().default(false),
         autoGenerateClasses: z.boolean().default(true),
         indentAccessSpecifiers: z.boolean().default(true),
+        customHeader: z.array(z.string()).default([]),
     }).parse(handle);
 
     return { ...config, handle };

--- a/src/generators.ts
+++ b/src/generators.ts
@@ -6,7 +6,8 @@ import { Config, FileInfo, HeaderGenerator as HeaderGenerators } from "./types";
 
 export const GENERATORS: HeaderGenerators = {
     pre2017: generatePre2017Header,
-    post2017: generatePost2017Header
+    post2017: generatePost2017Header,
+    custom: generateCustomHeader,
 };
 
 function generatePre2017Header(fileInfo: FileInfo, config: Config, date: Date): string {
@@ -37,6 +38,32 @@ function generatePost2017Header(fileInfo: FileInfo, _config: Config, date: Date)
         SYNTAX.commentMid[fileInfo.langId], " ", fileInfo.description as string, fileInfo.eol,
         SYNTAX.commentEnd[fileInfo.langId], fileInfo.eol, fileInfo.eol,
     );
+}
+
+function generateCustomHeader(fileInfo: FileInfo, config: Config): string {
+    const editContent = "";
+    return editContent.concat(
+        SYNTAX.commentStart[fileInfo.langId], fileInfo.eol,
+        config.customHeader.map((line) => SYNTAX.commentMid[fileInfo.langId] + " " + customArgs(fileInfo, line) + fileInfo.eol).join(""),
+        SYNTAX.commentEnd[fileInfo.langId], fileInfo.eol, fileInfo.eol,
+    );
+}
+
+// customArgs() replaces the placeholders in the custom header with the actual values.
+// It replaces:
+//     %FILENAME% with the name of the file.
+//     %PROJECTNAME% with the name of the project.
+//     %FILEPATH% with the path of the file.
+//     %DESCRIPTION% with the description of the file.
+// It returns the modified line.
+// To add a new placeholder, add a new line with the following format:
+//     line = line.replace(/%PLACEHOLDER%/g, newValue);
+function customArgs(fileInfo: FileInfo, line: string) {
+    line = line.replace(/%FILENAME%/g, path.basename(fileInfo.fileName));
+    line = line.replace(/%PROJECTNAME%/g, fileInfo.projName);
+    line = line.replace(/%FILEPATH%/g, path.dirname(fileInfo.fileName));
+    line = line.replace(/%DESCRIPTION%/g, fileInfo.description as string);
+    return line;
 }
 
 // getTabType() generates a tab string based on the user's editors settings.

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export type Config = {
     usePragmaOnce: boolean;
     autoGenerateClasses: boolean;
     indentAccessSpecifiers: boolean;
+    customHeader: string[];
 };
 
 export type HeaderGenerator = {


### PR DESCRIPTION
## Changes
I implemented a new configuration field for a custom header override. If set, it will replace the regular Epitech header for the one set in the config and adapt it to fit the languages specifications.

The configuration is an array of string:
```json
{
    "epitech-c-cpp-headers.customHeader": [
        "HEADER LINE 1",
        "HEADER LINE 2",
        "HEADER LINE 3",
        "..."
    ]
}
```

It also includes placeholders that will be replaced upon generation such as `%FILENAME%`, `%FILEPATH%`, `%PROJECTNAME%`, `%DESCRIPTION%`
More placeholders can be implemented in the future by editing the following:
https://github.com/IchiiDev/epitech-c-cpp-headers/blob/6ab07cb192afedccccd6c222da350c775d3f1f67/src/generators.ts#L61

## Why ?
This can be useful for side projects where a header is wanted but the Epitech format doesn't feel right to use. Instead of using another extension, we can now override the default header and keep using the shortcuts and keybinds we are used to.